### PR TITLE
Fix infinite loop in Canonical Collection

### DIFF
--- a/src/main/kotlin/AugmentedProduction.kt
+++ b/src/main/kotlin/AugmentedProduction.kt
@@ -15,4 +15,16 @@ class AugmentedProduction(
     fun moveToNextPosition(): AugmentedProduction {
         return AugmentedProduction(production, dotPosition + 1)
     }
+
+    override fun equals(other: Any?): Boolean {
+        return if (other is AugmentedProduction)
+            production.equalsProduction(other.production)
+        else false
+    }
+
+    override fun hashCode(): Int {
+        var result = production.hashCode()
+        result = 31 * result + dotPosition
+        return result
+    }
 }

--- a/src/main/kotlin/Parser.kt
+++ b/src/main/kotlin/Parser.kt
@@ -47,7 +47,7 @@ class Parser(val grammar: Grammar) {
                 allSymbols.forEach { symbol ->
                     val resultingClosure = goTo(state, symbol)
                     // TODO: second condition is not properly checked -> preexisting states get added every time resulting in an infinite loop
-                    if (resultingClosure.isNotEmpty() && states.find { it.productions == resultingClosure } == null) {
+                    if (resultingClosure.isNotEmpty() && states.find { it.productions.checkEqual(resultingClosure) } == null) {
                         tmpStates.add(State(nextState++, resultingClosure))
                         modified = true
                     }

--- a/src/main/kotlin/Util.kt
+++ b/src/main/kotlin/Util.kt
@@ -1,0 +1,11 @@
+fun Pair<String, List<String>>.equalsProduction(other: Pair<String, List<String>>): Boolean {
+    return this.first == other.first && this.second.checkEqual(other.second)
+}
+
+fun <T> List<T>.contains(other: List<T>): Boolean {
+    return other.find { e1 -> this.find { e2 -> e1?.equals(e2) ?: false } == null } == null
+}
+
+fun <T> List<T>.checkEqual(other: List<T>): Boolean {
+    return this.contains(other) && other.contains(this)
+}

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -1,13 +1,13 @@
 import java.io.File
 
 fun main() {
-    val grammar = Grammar(File("gr1BNF.txt"))
-//    val grammar = Grammar(File("gr1.txt"))
-    val menu = Menu(grammar)
+//    val grammar = Grammar(File("gr1BNF.txt"))
+    val grammar = Grammar(File("gr1.txt"))
+//    val menu = Menu(grammar)
 
-//    val parser = Parser(grammar)
+    val parser = Parser(grammar)
 //    parser.closure(grammar.augmentedProductionsForNonTerminal("(start)"))
-//    parser.canonicalCollection()
+    parser.canonicalCollection()
 
-    menu.display()
+//    menu.display()
 }


### PR DESCRIPTION
New closures were always being added due to faulty existence checks in the list of states (reference checks fail to identify otherwise equivalent closures)